### PR TITLE
Aggregation pipeline typings ($changeStream, $unionWith)

### DIFF
--- a/src/types/aggregation.assert.ts
+++ b/src/types/aggregation.assert.ts
@@ -125,7 +125,7 @@ ta.assert<
   >
 >()
 
-// Test Pipelink $changeStream
+// Test Pipeline $changeStream
 ta.assert<
   ta.Extends<
     { $changeStream: { fullDocument: 'updateLookup' } },
@@ -154,7 +154,7 @@ ta.assert<
   >
 >()
 
-// Test Pipelink $unionWith
+// Test Pipeline $unionWith
 ta.assert<
   ta.Extends<
     { $unionWith: { coll: string; pipeline: [{ $match: { a: [1, 2] } }] } },

--- a/src/types/aggregation.assert.ts
+++ b/src/types/aggregation.assert.ts
@@ -12,6 +12,11 @@ type ExampleTSchemaOther = {
   x: number
 }
 
+type ExampleTSchemaUnionWith = {
+  a: number[]
+  b: string
+}
+
 type CorrectLookupExample = {
   from: ''
   localField: 'a'
@@ -158,7 +163,7 @@ ta.assert<
 ta.assert<
   ta.Extends<
     { $unionWith: { coll: string; pipeline: [{ $match: { a: [1, 2] } }] } },
-    Pipeline<ExampleTSchema, ExampleTSchemaOther>
+    Pipeline<ExampleTSchema, ExampleTSchemaOther, ExampleTSchemaUnionWith>
   >
 >()
 ta.assert<
@@ -170,7 +175,7 @@ ta.assert<
           pipeline: [{ $match: { a: [1, 2] } }, { $merge: { into: string } }]
         }
       },
-      Pipeline<ExampleTSchema, ExampleTSchemaOther>
+      Pipeline<ExampleTSchema, ExampleTSchemaOther, ExampleTSchemaUnionWith>
     >
   >
 >()

--- a/src/types/aggregation.assert.ts
+++ b/src/types/aggregation.assert.ts
@@ -153,3 +153,24 @@ ta.assert<
     >
   >
 >()
+
+// Test Pipelink $unionWith
+ta.assert<
+  ta.Extends<
+    { $unionWith: { coll: string; pipeline: [{ $match: { a: [1, 2] } }] } },
+    Pipeline<ExampleTSchema, ExampleTSchemaOther>
+  >
+>()
+ta.assert<
+  ta.Not<
+    ta.Extends<
+      {
+        $unionWith: {
+          coll: string
+          pipeline: [{ $match: { a: [1, 2] } }, { $merge: { into: string } }]
+        }
+      },
+      Pipeline<ExampleTSchema, ExampleTSchemaOther>
+    >
+  >
+>()

--- a/src/types/aggregation.assert.ts
+++ b/src/types/aggregation.assert.ts
@@ -1,5 +1,6 @@
+import { ResumeToken } from 'mongodb'
 import * as ta from 'type-assertions'
-import { TsLookup, Pipeline } from './aggregation'
+import { Pipeline, TsLookup } from './aggregation'
 
 type ExampleTSchema = {
   a: number[]
@@ -119,6 +120,35 @@ ta.assert<
   ta.Not<
     ta.Extends<
       { $lookup: IncorrectLookupExample },
+      Pipeline<ExampleTSchema, ExampleTSchemaOther>
+    >
+  >
+>()
+
+// Test Pipelink $changeStream
+ta.assert<
+  ta.Extends<
+    { $changeStream: { fullDocument: 'updateLookup' } },
+    Pipeline<ExampleTSchema, ExampleTSchemaOther>
+  >
+>()
+ta.assert<
+  ta.Not<
+    ta.Extends<
+      {
+        $changeStream: {
+          resumeAfter: ResumeToken
+          startAfter: ResumeToken
+        }
+      },
+      Pipeline<ExampleTSchema, ExampleTSchemaOther>
+    >
+  >
+>()
+ta.assert<
+  ta.Not<
+    ta.Extends<
+      { $changeStream: { startAtOperationTime: number } },
       Pipeline<ExampleTSchema, ExampleTSchemaOther>
     >
   >

--- a/src/types/aggregation.ts
+++ b/src/types/aggregation.ts
@@ -4,6 +4,7 @@ import { TsFilter } from './filter'
 import { FlattenFilterPaths } from './flatten'
 import { TsProjection } from './projection'
 import { TsSort } from './sort'
+import { TsUnionWith } from './unionWith'
 import { RemodelType } from './util'
 
 /**
@@ -18,6 +19,7 @@ export declare type Pipeline<
   | { $sort: TsSort<TSchema> }
   | { $lookup: TsLookup<TSchema, TSchemaOther> }
   | { $changeStream: TsChangeStreamOptions }
+  | { $unionWith: TsUnionWith<TSchema, TSchemaOther> }
 
 export declare type TsLookup<
   TSchema extends Document,

--- a/src/types/aggregation.ts
+++ b/src/types/aggregation.ts
@@ -1,4 +1,5 @@
 import { AggregationCursor, Document } from 'mongodb'
+import { TsChangeStreamOptions } from './changeStream'
 import { TsFilter } from './filter'
 import { FlattenFilterPaths } from './flatten'
 import { TsProjection } from './projection'
@@ -16,6 +17,7 @@ export declare type Pipeline<
   | { $project: TsProjection<TSchema> }
   | { $sort: TsSort<TSchema> }
   | { $lookup: TsLookup<TSchema, TSchemaOther> }
+  | { $changeStream: TsChangeStreamOptions }
 
 export declare type TsLookup<
   TSchema extends Document,

--- a/src/types/aggregation.ts
+++ b/src/types/aggregation.ts
@@ -12,22 +12,23 @@ import { RemodelType } from './util'
  */
 export declare type Pipeline<
   TSchema extends Document,
-  TSchemaOther extends Document
+  TSchemaLookup extends Document,
+  TSchemaUnionWith extends Document = Document
 > =
   | { $match: TsFilter<TSchema> }
   | { $project: TsProjection<TSchema> }
   | { $sort: TsSort<TSchema> }
-  | { $lookup: TsLookup<TSchema, TSchemaOther> }
+  | { $lookup: TsLookup<TSchema, TSchemaLookup> }
   | { $changeStream: TsChangeStreamOptions }
-  | { $unionWith: TsUnionWith<TSchema, TSchemaOther> }
+  | { $unionWith: TsUnionWith<TSchemaUnionWith> }
 
 export declare type TsLookup<
   TSchema extends Document,
-  TSchemaOther extends Document
+  TSchemaLookup extends Document
 > = {
   from: string
   localField: FlattenFilterPaths<TSchema>
-  foreignField: FlattenFilterPaths<TSchemaOther>
+  foreignField: FlattenFilterPaths<TSchemaLookup>
   as: string
 }
 

--- a/src/types/changeStream.assert.ts
+++ b/src/types/changeStream.assert.ts
@@ -2,7 +2,7 @@ import { ResumeToken, Timestamp } from 'mongodb'
 import * as ta from 'type-assertions'
 import { TsChangeStreamOptions } from './changeStream'
 
-// Test all options are optional
+// Test all fields are optional
 ta.assert<ta.Extends<{}, TsChangeStreamOptions>>()
 
 // Test ChageStreamOptions equivalence

--- a/src/types/changeStream.assert.ts
+++ b/src/types/changeStream.assert.ts
@@ -1,0 +1,121 @@
+import { ResumeToken, Timestamp } from 'mongodb'
+import * as ta from 'type-assertions'
+import { TsChangeStreamOptions } from './changeStream'
+
+// Test all options are optional
+ta.assert<ta.Extends<{}, TsChangeStreamOptions>>()
+
+// Test ChageStreamOptions equivalence
+ta.assert<ta.Not<ta.Extends<string, TsChangeStreamOptions>>>()
+
+// Test allChangesForCluster field
+ta.assert<
+  ta.Extends<{ allChangesForCluster: boolean }, TsChangeStreamOptions>
+>()
+ta.assert<
+  ta.Not<ta.Extends<{ allChangesForCluster: number }, TsChangeStreamOptions>>
+>()
+
+// Test fullDocument field
+ta.assert<
+  ta.Extends<
+    { fullDocument: 'changeStreamPreAndPostImages' },
+    TsChangeStreamOptions
+  >
+>()
+ta.assert<ta.Not<ta.Extends<{ fullDocument: string }, TsChangeStreamOptions>>>()
+ta.assert<ta.Not<ta.Extends<{ fullDocument: number }, TsChangeStreamOptions>>>()
+
+// Test fullDocumentBeforeChange field
+ta.assert<
+  ta.Extends<
+    { fullDocumentBeforeChange: 'whenAvailable' },
+    TsChangeStreamOptions
+  >
+>()
+ta.assert<
+  ta.Not<
+    ta.Extends<{ fullDocumentBeforeChange: string }, TsChangeStreamOptions>
+  >
+>()
+ta.assert<
+  ta.Not<
+    ta.Extends<{ fullDocumentBeforeChange: number }, TsChangeStreamOptions>
+  >
+>()
+
+// Test resumeAfter field
+ta.assert<ta.Extends<{ resumeAfter: ResumeToken }, TsChangeStreamOptions>>()
+
+// Test showExpandedEvents field
+ta.assert<ta.Extends<{ showExpandedEvents: boolean }, TsChangeStreamOptions>>()
+ta.assert<
+  ta.Not<ta.Extends<{ showExpandedEvents: 1 }, TsChangeStreamOptions>>
+>()
+ta.assert<
+  ta.Not<ta.Extends<{ showExpandedEvents: null }, TsChangeStreamOptions>>
+>()
+ta.assert<
+  ta.Not<ta.Extends<{ showExpandedEvents: string }, TsChangeStreamOptions>>
+>()
+
+// Test startAfter field
+ta.assert<ta.Extends<{ startAfter: ResumeToken }, TsChangeStreamOptions>>()
+
+// Test startAtOperationTime field
+ta.assert<
+  ta.Extends<{ startAtOperationTime: Timestamp }, TsChangeStreamOptions>
+>()
+ta.assert<
+  ta.Not<ta.Extends<{ startAtOperationTime: number }, TsChangeStreamOptions>>
+>()
+ta.assert<
+  ta.Not<ta.Extends<{ startAtOperationTime: string }, TsChangeStreamOptions>>
+>()
+
+// Test only one of resumeAfter, startAfter and startAtOperationTime fields can be used
+ta.assert<
+  ta.Not<
+    ta.Extends<
+      {
+        resumeAfter: ResumeToken
+        startAfter: ResumeToken
+      },
+      TsChangeStreamOptions
+    >
+  >
+>()
+ta.assert<
+  ta.Not<
+    ta.Extends<
+      {
+        resumeAfter: ResumeToken
+        startAtOperationTime: ResumeToken
+      },
+      TsChangeStreamOptions
+    >
+  >
+>()
+ta.assert<
+  ta.Not<
+    ta.Extends<
+      {
+        startAfter: ResumeToken
+        startAtOperationTime: ResumeToken
+      },
+      TsChangeStreamOptions
+    >
+  >
+>()
+ta.assert<
+  ta.Not<
+    ta.Extends<
+      {
+        resumeAfter: ResumeToken
+        startAfter: ResumeToken
+        startAtOperationTime: ResumeToken
+      },
+      TsChangeStreamOptions
+    >
+  >
+>()

--- a/src/types/changeStream.ts
+++ b/src/types/changeStream.ts
@@ -1,0 +1,25 @@
+import { OperationTime, ResumeToken } from 'mongodb'
+import { AllowOnlyOne } from './util'
+
+type ChangeStreamOptions = {
+  allChangesForCluster?: boolean
+  fullDocument?:
+    | 'default'
+    | 'required'
+    | 'whenAvailable'
+    | 'changeStreamPreAndPostImages'
+    | 'updateLookup'
+  fullDocumentBeforeChange?: 'off' | 'whenAvailable' | 'required'
+  resumeAfter?: ResumeToken
+  showExpandedEvents?: boolean
+  startAfter?: ResumeToken
+  startAtOperationTime?: OperationTime
+}
+
+/**
+ * https://www.mongodb.com/docs/v6.0/reference/operator/aggregation/changeStream/
+ */
+export declare type TsChangeStreamOptions = AllowOnlyOne<
+  ChangeStreamOptions,
+  'resumeAfter' | 'startAfter' | 'startAtOperationTime'
+>

--- a/src/types/unionWith.assert.ts
+++ b/src/types/unionWith.assert.ts
@@ -1,0 +1,71 @@
+import * as ta from 'type-assertions'
+import { TsUnionWith } from './unionWith'
+
+type ExampleTSchema = {
+  a: number[]
+  b: string
+  c: number
+}
+
+type ExampleTSchemaOther = {
+  x: number
+}
+
+// Test coll field requirement
+ta.assert<
+  ta.Not<ta.Extends<{}, TsUnionWith<ExampleTSchema, ExampleTSchemaOther>>>
+>()
+
+// Test coll field
+ta.assert<
+  ta.Extends<{ coll: string }, TsUnionWith<ExampleTSchema, ExampleTSchemaOther>>
+>()
+ta.assert<
+  ta.Not<
+    ta.Extends<{ coll: null }, TsUnionWith<ExampleTSchema, ExampleTSchemaOther>>
+  >
+>()
+ta.assert<
+  ta.Not<
+    ta.Extends<
+      { coll: number },
+      TsUnionWith<ExampleTSchema, ExampleTSchemaOther>
+    >
+  >
+>()
+
+// Test pipeline field
+ta.assert<
+  ta.Extends<
+    { coll: string; pipeline: [{ $match: { a: [1, 2] } }] },
+    TsUnionWith<ExampleTSchema, ExampleTSchemaOther>
+  >
+>()
+ta.assert<
+  ta.Extends<
+    { coll: string; pipeline: [] },
+    TsUnionWith<ExampleTSchema, ExampleTSchemaOther>
+  >
+>()
+ta.assert<
+  ta.Not<
+    ta.Extends<
+      {
+        coll: string
+        pipeline: [{ $out: { db: string; coll: string } }]
+      },
+      TsUnionWith<ExampleTSchema, ExampleTSchemaOther>
+    >
+  >
+>()
+ta.assert<
+  ta.Not<
+    ta.Extends<
+      {
+        coll: string
+        pipeline: [{ $merge: { into: string } }]
+      },
+      TsUnionWith<ExampleTSchema, ExampleTSchemaOther>
+    >
+  >
+>()

--- a/src/types/unionWith.assert.ts
+++ b/src/types/unionWith.assert.ts
@@ -7,45 +7,23 @@ type ExampleTSchema = {
   c: number
 }
 
-type ExampleTSchemaOther = {
-  x: number
-}
-
 // Test coll field requirement
-ta.assert<
-  ta.Not<ta.Extends<{}, TsUnionWith<ExampleTSchema, ExampleTSchemaOther>>>
->()
+ta.assert<ta.Not<ta.Extends<{}, TsUnionWith<ExampleTSchema>>>>()
 
 // Test coll field
-ta.assert<
-  ta.Extends<{ coll: string }, TsUnionWith<ExampleTSchema, ExampleTSchemaOther>>
->()
-ta.assert<
-  ta.Not<
-    ta.Extends<{ coll: null }, TsUnionWith<ExampleTSchema, ExampleTSchemaOther>>
-  >
->()
-ta.assert<
-  ta.Not<
-    ta.Extends<
-      { coll: number },
-      TsUnionWith<ExampleTSchema, ExampleTSchemaOther>
-    >
-  >
->()
+ta.assert<ta.Extends<{ coll: string }, TsUnionWith<ExampleTSchema>>>()
+ta.assert<ta.Not<ta.Extends<{ coll: null }, TsUnionWith<ExampleTSchema>>>>()
+ta.assert<ta.Not<ta.Extends<{ coll: number }, TsUnionWith<ExampleTSchema>>>>()
 
 // Test pipeline field
 ta.assert<
   ta.Extends<
     { coll: string; pipeline: [{ $match: { a: [1, 2] } }] },
-    TsUnionWith<ExampleTSchema, ExampleTSchemaOther>
+    TsUnionWith<ExampleTSchema>
   >
 >()
 ta.assert<
-  ta.Extends<
-    { coll: string; pipeline: [] },
-    TsUnionWith<ExampleTSchema, ExampleTSchemaOther>
-  >
+  ta.Extends<{ coll: string; pipeline: [] }, TsUnionWith<ExampleTSchema>>
 >()
 ta.assert<
   ta.Not<
@@ -54,7 +32,7 @@ ta.assert<
         coll: string
         pipeline: [{ $out: { db: string; coll: string } }]
       },
-      TsUnionWith<ExampleTSchema, ExampleTSchemaOther>
+      TsUnionWith<ExampleTSchema>
     >
   >
 >()
@@ -65,7 +43,7 @@ ta.assert<
         coll: string
         pipeline: [{ $merge: { into: string } }]
       },
-      TsUnionWith<ExampleTSchema, ExampleTSchemaOther>
+      TsUnionWith<ExampleTSchema>
     >
   >
 >()

--- a/src/types/unionWith.ts
+++ b/src/types/unionWith.ts
@@ -4,13 +4,10 @@ import { Pipeline } from './aggregation'
 /**
  * https://www.mongodb.com/docs/v6.0/reference/operator/aggregation/unionWith/
  */
-export declare type TsUnionWith<
-  TSchema extends Document,
-  TSchemaOther extends Document
-> = {
+export declare type TsUnionWith<TSchema extends Document> = {
   coll: string
   pipeline?: Exclude<
-    Pipeline<TSchema, TSchemaOther>,
+    Pipeline<TSchema, Document>,
     // $out and $merge stages are not allowed in $unionWith
     { $out: unknown } | { $merge: unknown }
   >[]

--- a/src/types/unionWith.ts
+++ b/src/types/unionWith.ts
@@ -1,0 +1,17 @@
+import { Document } from 'mongodb'
+import { Pipeline } from './aggregation'
+
+/**
+ * https://www.mongodb.com/docs/v6.0/reference/operator/aggregation/unionWith/
+ */
+export declare type TsUnionWith<
+  TSchema extends Document,
+  TSchemaOther extends Document
+> = {
+  coll: string
+  pipeline?: Exclude<
+    Pipeline<TSchema, TSchemaOther>,
+    // $out and $merge stages are not allowed in $unionWith
+    { $out: unknown } | { $merge: unknown }
+  >[]
+}

--- a/src/types/util.ts
+++ b/src/types/util.ts
@@ -54,3 +54,11 @@ export declare type RecurRemoveNever<TSchema> = TSchema extends BaseTypes
   : TSchema extends ReadonlyArray<infer ArrayType>
   ? Array<RecurRemoveNever<ArrayType>>
   : never
+
+/**
+ * Allow only one of the keys in `Keys` to be present in `T`
+ */
+export type AllowOnlyOne<T, Keys extends keyof T = keyof T> = Omit<T, Keys> &
+  {
+    [K in keyof T]: Pick<T, K> & Partial<Record<Exclude<Keys, K>, never>>
+  }[Keys]


### PR DESCRIPTION
- Added typings and assertions for `$changeStream` (see [docs](https://www.mongodb.com/docs/v6.0/reference/operator/aggregation/changeStream/))
- Added typings and assertions for `$unionWith` (see [docs](https://www.mongodb.com/docs/v6.0/reference/operator/aggregation/unionWith/))
- Added a utility type `AllowOnlyOne` in `types/util.ts`