### PR TITLE
Make $in and $nin in .filter support discriminated unions

### DIFF
--- a/src/types/filter.assert.ts
+++ b/src/types/filter.assert.ts
@@ -186,3 +186,77 @@ ta.assert<ta.Not<ta.Extends<{ a: 2 }, WithOperator<{ a: number }[]>>>>()
 // Disallow extraneous fields, except when index supports number
 ta.assert<ta.Not<ta.Extends<{ z: 2 }, TsFilter<{ a: number; b: string[] }>>>>()
 ta.assert<ta.Extends<{ z: 2 }, TsFilter<{ a: number; b: string[] }, number>>>()
+
+
+// Test WithRecordOperator with unions
+type ExampleUnion = {
+  type: 'a' | 'b' | 'c' | 'd',
+  nested: { a: 1 | 2 | 3 } | { b: 4 | 5 | 6 }
+}
+
+ta.assert<
+  ta.Extends<{ type: { $in: ['a', 'c'] } }, WithRecordOperator<ExampleUnion>>
+>()
+ta.assert<
+  ta.Not<ta.Extends<{ type: { $in: ['d', 'f'] } }, WithRecordOperator<ExampleUnion>>>
+>()
+
+ta.assert<
+  ta.Extends<{ 'nested.a': { $in: [1, 2] } }, WithRecordOperator<ExampleUnion>>
+>()
+ta.assert<
+  ta.Extends<{ 'nested.b': { $in: [4, 6] } }, WithRecordOperator<ExampleUnion>>
+>()
+ta.assert<
+  ta.Not<ta.Extends<{ 'nested.b': { $in: [1, 7] } }, WithRecordOperator<ExampleUnion>>>
+>()
+
+ta.assert<
+  ta.Extends<
+    { 'nested': { $in: [{ a: 1 }, { b: 5 }] } },
+    WithRecordOperator<ExampleUnion>
+  >
+>()
+ta.assert<
+  ta.Not<ta.Extends<
+    { 'nested': { $in: [{ a: 0 }, { b: 7 }] } },
+    WithRecordOperator<ExampleUnion>
+  >>
+>()
+
+ta.assert<
+  ta.Extends<{ type: { $in: ['a', 'c'] } }, TsFilter<ExampleUnion>>
+>()
+ta.assert<
+  ta.Not<ta.Extends<{ type: { $in: ['d', 'f'] } }, TsFilter<ExampleUnion>>>
+>()
+
+
+type ExampleDiscriminatedUnion =
+  | { type: 'a'; bar: string }
+  | { type: 'b'; baz: number }
+  | { type: 'c'; foo: { subtype: 'a' } | { subtype: 'b' } | { subtype: 'c' }}
+
+ta.assert<
+  ta.Extends<{ type: { $in: ['a', 'b'] } }, WithRecordOperator<ExampleDiscriminatedUnion>>
+>()
+ta.assert<
+  ta.Not<ta.Extends<{ type: { $in: ['c', 'd'] } }, WithRecordOperator<ExampleDiscriminatedUnion>>>
+>()
+ta.assert<
+  ta.Extends<{ baz: { $in: [1, 2] }, bar: { $in: ["test1", "test2"] }}, WithRecordOperator<ExampleDiscriminatedUnion>>
+>()
+
+ta.assert<
+  ta.Extends<{ 'foo.subtype': { $in: ['a', 'b'] } }, WithRecordOperator<ExampleDiscriminatedUnion>>
+>()
+ta.assert<
+  ta.Not<ta.Extends<{ 'foo.subtype': { $in: ['c', 'd'] } }, WithRecordOperator<ExampleDiscriminatedUnion>>>
+>()
+
+ta.assert<
+  ta.Extends<{ type: { $in: ['a', 'b'] } }, TsFilter<ExampleDiscriminatedUnion>>
+>()
+ta.assert<
+  ta.Not<ta.Extends<{ 'foo.subtype': { $in: ['c', 'd'] } }, TsFilter<ExampleDiscriminatedUnion>>>
+>()

--- a/src/types/filter.assert.ts
+++ b/src/types/filter.assert.ts
@@ -1,6 +1,6 @@
 import { ObjectId } from 'mongodb'
 import * as ta from 'type-assertions'
-import { FilterType, TsFilter, WithOperator } from './filter'
+import { FilterType, TsFilter, WithOperator, WithRecordOperator } from './filter'
 
 // cannot use `number` in template type of object key; works if you use specific numbers
 ta.assert<ta.Extends<'a20b', `a${number}b`>>()

--- a/src/types/filter.ts
+++ b/src/types/filter.ts
@@ -82,7 +82,7 @@ export type WithNegatableOperator<Expr> =
 export type WithRecordOperator<
   TSchema,
   IndexType extends number = 0
-> = TSchema extends NonArrayObject
+> = [TSchema] extends [NonArrayObject]
   ? {
       readonly [Property in FlattenFilterPaths<
         WithId<TSchema>,
@@ -95,14 +95,14 @@ export type WithOperator<Field, IndexType extends number = 0> =
   | RecurPartial<Field>
   | WithNegatableOperator<
       WithElementOperator &
-        WithRecordOperator<Field, IndexType> &
-        WithComparisonOperator<Field> &
-        WithStringOperator<Field> &
-        WithTextSearchOperator &
-        WithEqualityOperator<Field> &
-        WithArrayOperator<Field> &
-        WithGeoSpatialQueryOperator<Field> &
-        WithBitwiseOperator<Field>
+      WithRecordOperator<Field, IndexType> &
+      WithComparisonOperator<Field> &
+      WithStringOperator<Field> &
+      WithTextSearchOperator &
+      WithEqualityOperator<Field> &
+      WithArrayOperator<Field> &
+      WithGeoSpatialQueryOperator<Field> &
+      WithBitwiseOperator<Field>
     >
 
 /**

--- a/src/types/filter.ts
+++ b/src/types/filter.ts
@@ -82,6 +82,8 @@ export type WithNegatableOperator<Expr> =
 export type WithRecordOperator<
   TSchema,
   IndexType extends number = 0
+  // HACK: wrapping into [] here to disable distributive behavior of conditional type and make it work with discriminated unions
+  // source of hack https://stackoverflow.com/questions/55542332/typescript-conditional-type-with-discriminated-union/55542463#55542463
 > = [TSchema] extends [NonArrayObject]
   ? {
       readonly [Property in FlattenFilterPaths<


### PR DESCRIPTION
Let's take a discriminated union
```ts
type Union = { type: 'a' } | { type: 'b' }
```
### Before
Before this change when you pass the union to `WithRecordOperator` it would generate type like this.
![image](https://user-images.githubusercontent.com/28788017/228966119-378e6023-8304-479b-9cb3-71ba82aa26a4.png)
It is due to distributive behavior of conditional types. It "distributes" the mapped type over each member of union.

It resulted in errors like this.
![image](https://user-images.githubusercontent.com/28788017/228966466-5e696897-cc4a-4250-905f-3144a74f7469.png)

---
### After
After the change usage of `WithRecordOperator` results in type like this and fixes the error.
![image](https://user-images.githubusercontent.com/28788017/228967522-600eeea0-641a-49a9-896b-4b865002aa30.png)

I found the solution in here (also, added with a comment to the code)
https://stackoverflow.com/questions/55542332/typescript-conditional-type-with-discriminated-union/55542463#55542463

---
### There is a gotcha :exclamation:

It seems that the change introduced an problem with `tsc`.
First when I tried to run `pnpm run typecheck` it failed with `JavaScript heap out of memory`. 
![image](https://user-images.githubusercontent.com/28788017/228968871-96f65321-3e68-4224-97e3-4a498a0ae67b.png)

Then I called it with additional space (which is not great already)
`NODE_OPTIONS='--max-old-space-size=8192' tsc --noEmit --skipLibCheck`
![image](https://user-images.githubusercontent.com/28788017/228968983-8b2a850f-7fb7-4a48-8e41-0cb459061826.png)

The last thing I tried was to update TS version to '4.9.5' (found in [Github issue](https://github.com/chakra-ui/chakra-ui/issues/3714)). Now it looks so
![image](https://user-images.githubusercontent.com/28788017/228969086-07877939-4e86-4882-95fd-6a7416c8ad4d.png)

If I revert changes it works fine. Changes seem to be purely of type "TS, I want to disable unwanted feature in this case, so using this hack that doesn't affect anything outside".
Any ideas how to fix it?
Also, how do you feel about tests? Do they stick with the conventions fine?

And in general, please share your feedback, I'll be happy to make adjustments if needed!