### PR TITLE
added object type for the typecheck

### DIFF
--- a/src/types/filter.assert.ts
+++ b/src/types/filter.assert.ts
@@ -193,6 +193,8 @@ type ExampleObjectUnion =
   | { type: 'b'; bar: string }
   | { type: 'c'; baz: boolean }
   | { type: 'd'; zod: ObjectId }
+  | { type: {}; fed: object}
+
 
 ta.assert<
   ta.Extends<{ $in: ['a', 'b'] }, FilterType<ExampleObjectUnion, 'type'>>


### PR DESCRIPTION
The task is to ensure the filter assertion runs without fail but it currently fails because of the types defined on the ExampleObjectUnion 
```
type ExampleObjectUnion =
  | { type: 'a'; foo: number }
  | { type: 'b'; bar: string }
  | { type: 'c'; baz: boolean }
  | { type: 'd'; zod: ObjectId }
``` 
do not support object
so i added object type since what we are passing to the asset is an object
```
type ExampleObjectUnion =
  | { type: 'a'; foo: number }
  | { type: 'b'; bar: string }
  | { type: 'c'; baz: boolean }
  | { type: 'd'; zod: ObjectId }
  | { type: {}; fed: object}

```
The  `pnpm typecheck`
![Screenshot 2023-03-31 at 13 48 15](https://user-images.githubusercontent.com/10176093/229100646-3228f18b-d337-4d1d-8b5c-949f9b93f52e.png)

The `pnpm assert`
![Screenshot 2023-03-31 at 13 50 59](https://user-images.githubusercontent.com/10176093/229101136-d1465163-a4df-4364-8822-d2bb09f8603b.png)



