### PR TITLE
Fix $in operation for discriminated union

### DIFF
--- a/src/types/filter.ts
+++ b/src/types/filter.ts
@@ -18,7 +18,7 @@ export type WithElementOperator = {
 export type WithEqualityOperator<Field> = {
   $eq?: Field
   $ne?: Field
-  $in?: readonly Field[]
+  $in?: Field extends string ? readonly string[] : readonly Field[]
   $nin?: readonly Field[]
 }
 


### PR DESCRIPTION
Allows the $in operator to work with a discriminated union. Only worked with a type union previously.