### PR TITLE
Fix $in operator for discriminated unions

### DIFF
--- a/src/types/filter.assert.ts
+++ b/src/types/filter.assert.ts
@@ -186,3 +186,28 @@ ta.assert<ta.Not<ta.Extends<{ a: 2 }, WithOperator<{ a: number }[]>>>>()
 // Disallow extraneous fields, except when index supports number
 ta.assert<ta.Not<ta.Extends<{ z: 2 }, TsFilter<{ a: number; b: string[] }>>>>()
 ta.assert<ta.Extends<{ z: 2 }, TsFilter<{ a: number; b: string[] }, number>>>()
+
+// Challenge
+type ExampleObjectUnion =
+  | { type: 'a'; foo: number }
+  | { type: 'b'; bar: string }
+  | { type: 'c'; baz: boolean }
+  | { type: 'd'; zod: ObjectId }
+
+ta.assert<
+  ta.Extends<{ $in: ['a', 'b'] }, FilterType<ExampleObjectUnion, 'type'>>
+>()
+ta.assert<
+  ta.Extends<{ type: { $in: ['a', 'b'] } }, TsFilter<ExampleObjectUnion>>
+>()
+
+type ExampleTypeUnion = {
+  type: 'a' | 'b' | 'c' | 'd'
+}
+
+ta.assert<
+  ta.Extends<{ $in: ['a', 'b'] }, FilterType<ExampleTypeUnion, 'type'>>
+>()
+ta.assert<
+  ta.Extends<{ type: { $in: ['a', 'b'] } }, TsFilter<ExampleTypeUnion>>
+>()

--- a/src/types/filter.assert.ts
+++ b/src/types/filter.assert.ts
@@ -187,7 +187,6 @@ ta.assert<ta.Not<ta.Extends<{ a: 2 }, WithOperator<{ a: number }[]>>>>()
 ta.assert<ta.Not<ta.Extends<{ z: 2 }, TsFilter<{ a: number; b: string[] }>>>>()
 ta.assert<ta.Extends<{ z: 2 }, TsFilter<{ a: number; b: string[] }, number>>>()
 
-// Challenge
 type ExampleObjectUnion =
   | { type: 'a'; foo: number }
   | { type: 'b'; bar: string }
@@ -200,6 +199,14 @@ ta.assert<
 ta.assert<
   ta.Extends<{ type: { $in: ['a', 'b'] } }, TsFilter<ExampleObjectUnion>>
 >()
+ta.assert<
+  ta.Not<
+    ta.Extends<
+      { type: { $in: ['a', 'b', 'not-type'] } },
+      TsFilter<ExampleObjectUnion>
+    >
+  >
+>()
 
 type ExampleTypeUnion = {
   type: 'a' | 'b' | 'c' | 'd'
@@ -207,6 +214,14 @@ type ExampleTypeUnion = {
 
 ta.assert<
   ta.Extends<{ $in: ['a', 'b'] }, FilterType<ExampleTypeUnion, 'type'>>
+>()
+ta.assert<
+  ta.Not<
+    ta.Extends<
+      { $in: ['a', 'b', 'not-type'] },
+      FilterType<ExampleTypeUnion, 'type'>
+    >
+  >
 >()
 ta.assert<
   ta.Extends<{ type: { $in: ['a', 'b'] } }, TsFilter<ExampleTypeUnion>>

--- a/src/types/filter.ts
+++ b/src/types/filter.ts
@@ -2,7 +2,7 @@ import { Document, ObjectId, WithId } from 'mongodb'
 import { WithBitwiseOperator } from './bitwise'
 import { FlattenFilterPaths, FlattenFilterType } from './flatten'
 import { WithGeoSpatialQueryOperator } from './geospatialQuery'
-import { NonArrayObject, RecurPartial } from './util'
+import { NonArrayObject, RecurFlattenUnion, RecurPartial } from './util'
 
 /**
  * https://docs.mongodb.com/manual/reference/operator/query-element/
@@ -129,4 +129,8 @@ export declare type FilterType<
 export type TsFilter<
   TSchema extends Document,
   IndexType extends number = 0
-> = WithLogicalOperators<WithOperator<TSchema, IndexType>>
+> = RecurFlattenUnion<TSchema> extends TSchema // This checks if the schema does not contain a discriminated union
+  ? WithLogicalOperators<WithOperator<TSchema, IndexType>>
+  // If it does contain a discriminated union, we evaluate once more, only with the common properties og the union
+  // Because some operators rely on discriminated unions, we can't simply skip evaluating the whole expression
+  : WithLogicalOperators<WithOperator<TSchema, IndexType>> | WithLogicalOperators<WithOperator<RecurFlattenUnion<TSchema>, IndexType>>

--- a/src/types/filter.ts
+++ b/src/types/filter.ts
@@ -131,6 +131,9 @@ export type TsFilter<
   IndexType extends number = 0
 > = RecurFlattenUnion<TSchema> extends TSchema // This checks if the schema does not contain a discriminated union
   ? WithLogicalOperators<WithOperator<TSchema, IndexType>>
-  // If it does contain a discriminated union, we evaluate once more, only with the common properties og the union
-  // Because some operators rely on discriminated unions, we can't simply skip evaluating the whole expression
-  : WithLogicalOperators<WithOperator<TSchema, IndexType>> | WithLogicalOperators<WithOperator<RecurFlattenUnion<TSchema>, IndexType>>
+  : // If it does contain a discriminated union, we evaluate once more, only with the common properties og the union
+    // Because some operators rely on discriminated unions, we can't simply skip evaluating the whole expression
+    | WithLogicalOperators<WithOperator<TSchema, IndexType>>
+      | WithLogicalOperators<
+          WithOperator<RecurFlattenUnion<TSchema>, IndexType>
+        >

--- a/src/types/util.assert.ts
+++ b/src/types/util.assert.ts
@@ -9,7 +9,8 @@ import {
   RecurPartial,
   RecurRemoveNever,
   _Doc,
-  RecurFlattenUnion, FlattenUnion,
+  RecurFlattenUnion,
+  FlattenUnion,
 } from './util'
 
 // Test DocumentWithId
@@ -114,7 +115,6 @@ ta.assert<
     { type: 'a' | 'b' }
   >
 >()
-
 
 // Test RecurFlattenUnion
 // Should not affect base types

--- a/src/types/util.assert.ts
+++ b/src/types/util.assert.ts
@@ -9,6 +9,7 @@ import {
   RecurPartial,
   RecurRemoveNever,
   _Doc,
+  RecurFlattenUnion, FlattenUnion,
 } from './util'
 
 // Test DocumentWithId
@@ -95,5 +96,52 @@ ta.assert<
   ta.Equal<
     RecurRemoveNever<{ a: number[]; b: { c: string; d: never }[] }>,
     { a: number[]; b: { c: string }[] }
+  >
+>()
+
+// Test FlattenUnion
+// Should not affect normal objects
+ta.assert<
+  ta.Equal<
+    FlattenUnion<{ foo: number; bar: string }>,
+    { foo: number; bar: string }
+  >
+>()
+// Should flatten unions
+ta.assert<
+  ta.Equal<
+    FlattenUnion<{ type: 'a'; foo: number } | { type: 'b'; bar: string }>,
+    { type: 'a' | 'b' }
+  >
+>()
+
+
+// Test RecurFlattenUnion
+// Should not affect base types
+ta.assert<ta.Equal<RecurFlattenUnion<string>, string>>()
+// Should not affect arrays
+ta.assert<ta.Equal<RecurFlattenUnion<number[]>, number[]>>()
+// Should not affect normal objects
+ta.assert<
+  ta.Equal<
+    RecurFlattenUnion<{ foo: number; bar: string }>,
+    { foo: number; bar: string }
+  >
+>()
+// Should flatten unions
+ta.assert<
+  ta.Equal<
+    RecurFlattenUnion<{ type: 'a'; foo: number } | { type: 'b'; bar: string }>,
+    { type: 'a' | 'b' }
+  >
+>()
+// Should flatten unions in objects
+ta.assert<
+  ta.Equal<
+    RecurFlattenUnion<
+      | { deep: { type: 'a'; foo: number } }
+      | { deep: { type: 'b'; bar: string } }
+    >,
+    { deep: { type: 'a' | 'b' } }
   >
 >()

--- a/src/types/util.ts
+++ b/src/types/util.ts
@@ -62,3 +62,20 @@ export type AllowOnlyOne<T, Keys extends keyof T = keyof T> = Omit<T, Keys> &
   {
     [K in keyof T]: Pick<T, K> & Partial<Record<Exclude<Keys, K>, never>>
   }[Keys]
+
+/**
+ * Extract what is common in all elements of a union. In discriminated type unions, it will only keep the discriminator,
+ * and it will be narrowly typed. For example: { type: 'a'; foo: number } | { type: 'b'; bar: string } => { type: 'a' | 'b }
+ */
+export type FlattenUnion<T> = Pick<T, keyof T>
+
+/**
+ * Apply the FlattenUnion type recursively, extracting  what is common in all elements of all unions.
+ */
+export declare type RecurFlattenUnion<T, F = FlattenUnion<T>> = T extends BaseTypes
+  ? T
+  : T extends ReadonlyArray<infer ArrayType>
+  ? ReadonlyArray<RecurFlattenUnion<ArrayType>>
+  : T extends Record<string, unknown>
+  ? { readonly [P in keyof F]?: RecurFlattenUnion<F[P]> }
+  : never

--- a/src/types/util.ts
+++ b/src/types/util.ts
@@ -65,7 +65,8 @@ export type AllowOnlyOne<T, Keys extends keyof T = keyof T> = Omit<T, Keys> &
 
 /**
  * Extract what is common in all elements of a union. In discriminated type unions, it will only keep the discriminator,
- * and it will be narrowly typed. For example: { type: 'a'; foo: number } | { type: 'b'; bar: string } => { type: 'a' | 'b }
+ * and it will be narrowly typed. Should not be used in base types or arrays.
+ * For example: { type: 'a'; foo: number } | { type: 'b'; bar: string } => { type: 'a' | 'b }
  */
 export type FlattenUnion<T> = Pick<T, keyof T>
 
@@ -77,8 +78,10 @@ export declare type RecurFlattenUnion<
   F = FlattenUnion<T>
 > = T extends BaseTypes
   ? T
+  : T extends Array<infer ArrayType>
+  ? Array<RecurFlattenUnion<ArrayType>>
   : T extends ReadonlyArray<infer ArrayType>
   ? ReadonlyArray<RecurFlattenUnion<ArrayType>>
   : T extends Record<string, unknown>
-  ? { readonly [P in keyof F]?: RecurFlattenUnion<F[P]> }
+  ? { readonly [P in keyof F]: RecurFlattenUnion<F[P]> }
   : never

--- a/src/types/util.ts
+++ b/src/types/util.ts
@@ -72,7 +72,10 @@ export type FlattenUnion<T> = Pick<T, keyof T>
 /**
  * Apply the FlattenUnion type recursively, extracting  what is common in all elements of all unions.
  */
-export declare type RecurFlattenUnion<T, F = FlattenUnion<T>> = T extends BaseTypes
+export declare type RecurFlattenUnion<
+  T,
+  F = FlattenUnion<T>
+> = T extends BaseTypes
   ? T
   : T extends ReadonlyArray<infer ArrayType>
   ? ReadonlyArray<RecurFlattenUnion<ArrayType>>


### PR DESCRIPTION
## The Problem
The $in operator was not working with discriminated unions, as shown by the assertion:
`ta.assert<ta.Extends<{ type: { $in: ['a', 'b'] } }, TsFilter<ExampleObjectUnion>>>()`

## The cause
This happens because Typescript does not merge related fields in discriminated unions but evaluate each variant separately, i. e. `{ type: 'a'; foo: number }|{ type: 'b'; bar: string }` does not become `{ type: 'a'|'b'; foo?: number; bar?: string }`. This behavior is what lets us check the discriminator in an if statement and use the properties of that variant right after.
However, this led to an incorrect type on the $in operator. Following the example above, the $in type would be ('a'[])|('b'[]). This meant that `{ $in: ['a'] } and { $in: ['b', 'b'] }` would both work, but `{ $in: ['a', 'b'] }` wouldn't.

## The solution
It's possible to merge discriminated unions, keeping only the common fields, and with correct narrow typing with the following type: 
`type FlattenUnion<T> = Pick<T, keyof T>`. This works because the keyof operator only yields keys that are present in all members of a union.
But if we apply this type in every case, operators that rely on discriminators will stop working (like geospatial). So, the solution checks if the filter type is indeed a discriminated union. If so, it evaluates the type normally AND the type flattened recursively.

## Why it is a good solution
It's not the most obvious/simple solution, but it has some advantages. First, it's not specific to strings, so it works with boolean discriminators (which are rare, but not impossible). Also, because it's not bound to the $in operator, it may prevent similar issues in the future. Finally, it doesn't break type safety for literals in the operator.

## Some considerations
Bacause it implements a recursive type, it might add some overhead for checking really huge types.