### PR TITLE
fix: close connections after tests

### DIFF
--- a/test/converter.test.ts
+++ b/test/converter.test.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod'
 import { mkTsCollection, WithTime } from '../src'
 import { convertReadWriteCollection } from '../src/converter'
-import { setupDb } from './util'
+import { closeDb, setupDb } from './util'
 
 const Example = z.object({
   a: z.string(),
@@ -56,3 +56,5 @@ test('find', async () => {
   ).resolves.toEqual([])
   expect(() => collection.find({ a: 'another value' })).toThrow()
 })
+
+afterAll(() => closeDb())

--- a/test/geoSpatialQuery.test.ts
+++ b/test/geoSpatialQuery.test.ts
@@ -1,5 +1,5 @@
 import { TsLegacyCoordinates } from '../src/types/geojson'
-import { mkTsTestCollection } from './util'
+import { closeDb, mkTsTestCollection } from './util'
 
 type Example = {
   Name: string
@@ -77,3 +77,5 @@ describe('Near', () => {
     expect(result[0]).toStrictEqual(locations[1])
   })
 })
+
+afterAll(() => closeDb())

--- a/test/middleware.test.ts
+++ b/test/middleware.test.ts
@@ -1,5 +1,5 @@
 import { addMiddleware } from '../src'
-import { mkTsTestCollection } from './util'
+import { closeDb, mkTsTestCollection } from './util'
 
 type Example = { a: number }
 
@@ -43,3 +43,5 @@ test('listening on find', async () => {
   expect(before).toHaveBeenCalledWith([{}])
   expect(after).toHaveBeenCalledTimes(1)
 })
+
+afterAll(() => closeDb())

--- a/test/preExistingId.test.ts
+++ b/test/preExistingId.test.ts
@@ -1,5 +1,5 @@
 import { ObjectId } from 'mongodb'
-import { mkTsTestCollection } from './util'
+import { closeDb, mkTsTestCollection } from './util'
 
 type Example = { a: number; _id: ObjectId }
 
@@ -13,3 +13,5 @@ test('set on dot notation', async () => {
     /E11000 duplicate key error dup key/
   )
 })
+
+afterAll(() => closeDb())

--- a/test/projection.test.ts
+++ b/test/projection.test.ts
@@ -1,5 +1,5 @@
 import z from 'zod'
-import { mkTsTestCollection } from './util'
+import { closeDb, mkTsTestCollection } from './util'
 
 const Example = z.object({
   a: z.object({ b: z.number(), c: z.string() }),
@@ -42,3 +42,5 @@ test('exclude without dot notation', async () => {
 
   expect(result).toEqual({ a: { b: 2, c: 's' } })
 })
+
+afterAll(() => closeDb())

--- a/test/time-collection.test.ts
+++ b/test/time-collection.test.ts
@@ -1,7 +1,7 @@
 import { ObjectId } from 'mongodb'
 import { z } from 'zod'
 import { convertToTimeCollection, mkTsCollection, WithTime } from '../src'
-import { setupDb } from './util'
+import { closeDb, setupDb } from './util'
 
 const delay = (ms: number) => {
   return new Promise((resolve) => {
@@ -58,3 +58,5 @@ test('updateOne', async () => {
   expect(result?.createdAt.getTime()).toBeLessThan(time)
   expect(result?.updatedAt.getTime()).toBeGreaterThan(time)
 })
+
+afterAll(() => closeDb())

--- a/test/update.set.test.ts
+++ b/test/update.set.test.ts
@@ -1,4 +1,4 @@
-import { mkTsTestCollection } from './util'
+import { closeDb, mkTsTestCollection } from './util'
 
 type Example = { a: { b: number; c?: string }; d: number }
 
@@ -34,3 +34,5 @@ test('set other key', async () => {
   const result3 = await col.findOne({ _id: id })
   expect(result3).toStrictEqual({ _id: id, a: { b: 2, c: 'hi' }, d: 10 })
 })
+
+afterAll(() => closeDb())

--- a/test/update.unset.test.ts
+++ b/test/update.unset.test.ts
@@ -1,4 +1,4 @@
-import { mkTsTestCollection } from './util'
+import { closeDb, mkTsTestCollection } from './util'
 
 type Example = { a: { b: number; c?: string }; d: number }
 
@@ -34,3 +34,5 @@ test('unset other key', async () => {
   const result3 = await col.findOne({ _id: id })
   expect(result3).toStrictEqual({ _id: id, a: { b: 2, c: 'hi' } })
 })
+
+afterAll(() => closeDb())

--- a/test/util.ts
+++ b/test/util.ts
@@ -14,9 +14,9 @@ export const setupDb = async (): Promise<Db> => {
   return client.db() as Db
 }
 
+export const closeDb = async (): Promise<void> => await client?.close()
+
 export const mkTsTestCollection = async <TSchema extends Document>() => {
   const db = await setupDb()
   return mkTsCollection<TSchema>(db, Math.random().toString())
 }
-
-afterAll(async () => await client?.close())

--- a/test/util.ts
+++ b/test/util.ts
@@ -18,3 +18,5 @@ export const mkTsTestCollection = async <TSchema extends Document>() => {
   const db = await setupDb()
   return mkTsCollection<TSchema>(db, Math.random().toString())
 }
+
+afterAll(async () => await client?.close())


### PR DESCRIPTION
Task:
https://www.notion.so/Add-shelf-jest-mongodb-to-ts-mongo-14a787beca7c4b95bfbac986598e27cb?pvs=4

This fixes the persisting connections issue after running the jest tests.