### PR TITLE
Feat: Support replacements on time collection

### DIFF
--- a/src/time-collection.ts
+++ b/src/time-collection.ts
@@ -1,4 +1,4 @@
-import { Document, OptionalUnlessRequiredId, WithId } from 'mongodb'
+import { Document, OptionalUnlessRequiredId, WithId, WithoutId } from 'mongodb'
 import { TsReadWriteCollection } from './collection'
 import { convertReadWriteCollection } from './converter'
 import { DocumentWithId, TimeOptions, TsUpdate } from './types'
@@ -13,6 +13,8 @@ export type DocumentWithIdTime = DocumentWithId & {
   updatedAt: Date
 }
 
+/** Note that `replaceOne` and `findOneAndReplace` methods will overwrite
+ * the `createdAt` and `updatedAt` fields with a new Date value. */
 export const convertToTimeCollection = <TSchema extends Document>(
   collection: TsReadWriteCollection<
     WithTime<TSchema>,
@@ -45,8 +47,9 @@ export const convertToTimeCollection = <TSchema extends Document>(
         } as any,
       }
     },
-    preReplace: () => {
-      throw Error('Does not support replace')
+    preReplace: (obj: WithoutId<TSchema>): WithoutId<WithTime<TSchema>> => {
+      const date = new Date()
+      return { ...obj, createdAt: date, updatedAt: date } as any
     },
     postFind: (obj) => obj,
     preFilter: (obj) => obj,

--- a/src/time-collection.ts
+++ b/src/time-collection.ts
@@ -13,8 +13,12 @@ export type DocumentWithIdTime = DocumentWithId & {
   updatedAt: Date
 }
 
-/** Note that `replaceOne` and `findOneAndReplace` methods will overwrite
- * the `createdAt` and `updatedAt` fields with a new Date value. */
+/**
+ * Note that `replaceOne` and `findOneAndReplace` methods will overwrite the
+ * `createdAt` and `updatedAt` fields with a new Date value. The replace methods
+ * with option `upsert=True` can create a new document and need to set
+ * `createdAt` to guarantee the field is always set.
+ */
 export const convertToTimeCollection = <TSchema extends Document>(
   collection: TsReadWriteCollection<
     WithTime<TSchema>,

--- a/test/time-collection.test.ts
+++ b/test/time-collection.test.ts
@@ -76,4 +76,17 @@ test('updatedAt should not be updated if `setUpdatedAt` is false', async () => {
   )
 })
 
+test('replaceOne', async () => {
+  const collection = await initializeTimeCollection()
+  await collection.insertOne({ a: 'firstInsertion' })
+  const result1 = await collection.findOne({ a: 'firstInsertion' })
+  await delay(5)
+  await collection.replaceOne({ a: 'firstInsertion' }, { a: 'replaced' })
+  const result2 = await collection.findOne({ a: 'replaced' })
+  if (!result1 || !result2) {
+    throw new Error('db result is unexpectedly null')
+  }
+  expect(result1.createdAt.getTime()).toBeLessThan(result2.createdAt.getTime())
+})
+
 afterAll(() => closeDb())


### PR DESCRIPTION
Support the `replaceOne` and `findOneAndReplace` methods on time collections. The `replaceOne` and `findOneAndReplace` methods will overwrite the `createdAt` and `updatedAt` fields with a new Date value