### PR TITLE
Fix: insert methods removing _ids

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
       "semver": ">=7.5.2",
       "word-wrap": ">=1.2.4",
       "braces": ">=3.0.3",
-      "micromatch": ">=4.0.8"
+      "micromatch": ">=4.0.8",
+      "cross-spawn": ">=7.0.5"
     }
   },
   "exports": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,7 @@ overrides:
   word-wrap: '>=1.2.4'
   braces: '>=3.0.3'
   micromatch: '>=4.0.8'
+  cross-spawn: '>=7.0.5'
 
 importers:
 
@@ -1015,8 +1016,8 @@ packages:
   create-require@1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
 
-  cross-spawn@7.0.3:
-    resolution: {integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==}
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
   crypto-random-string@4.0.0:
@@ -4175,7 +4176,7 @@ snapshots:
 
   create-require@1.1.1: {}
 
-  cross-spawn@7.0.3:
+  cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
       shebang-command: 2.0.0
@@ -4351,7 +4352,7 @@ snapshots:
       '@nodelib/fs.walk': 1.2.8
       ajv: 6.12.6
       chalk: 4.1.2
-      cross-spawn: 7.0.3
+      cross-spawn: 7.0.6
       debug: 4.3.4
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
@@ -4411,7 +4412,7 @@ snapshots:
 
   execa@5.1.1:
     dependencies:
-      cross-spawn: 7.0.3
+      cross-spawn: 7.0.6
       get-stream: 6.0.1
       human-signals: 2.1.0
       is-stream: 2.0.1
@@ -4423,7 +4424,7 @@ snapshots:
 
   execa@7.2.0:
     dependencies:
-      cross-spawn: 7.0.3
+      cross-spawn: 7.0.6
       get-stream: 6.0.1
       human-signals: 4.3.1
       is-stream: 3.0.0

--- a/src/zod-collection.ts
+++ b/src/zod-collection.ts
@@ -26,7 +26,8 @@ export const convertToZodCollection = <TSchema extends Document>(
           _id: z
             // Can't be instanceof(ObjectId) because the instanceof operator
             // doesn't work correctly when ts-mongo is imported by another lib
-            // This is similar to what we do with zod instance checking
+            // This is similar to what we do with zod instance checking here:
+            // https://github.com/cau777/zod/blob/ee7f929f6b145721e5f79ad8ba7a2357d32053f6/src/types.ts#L206-L226
             .instanceof(Object)
             .refine((obj) => obj.constructor.name === 'ObjectId')
             .optional(),

--- a/src/zod-collection.ts
+++ b/src/zod-collection.ts
@@ -1,7 +1,7 @@
 import { TsReadWriteCollection } from './collection'
 import z from 'zod'
 import { convertReadWriteCollection } from './converter'
-import { OptionalUnlessRequiredId, WithId, Document, ObjectId } from 'mongodb'
+import { OptionalUnlessRequiredId, WithId, Document } from 'mongodb'
 import { WithTime } from './time-collection'
 import { parseFieldsAsArrays, zodDeepPartial } from './zod-utils'
 

--- a/test/zod-collection.test.ts
+++ b/test/zod-collection.test.ts
@@ -35,6 +35,14 @@ test('Documents should be parsed correctly on insert', async () => {
   })
   expect(insertedId.equals(id)).toBeTruthy()
 
+  expect(() =>
+    zodCol.insertOne({ a: 'string', b: 'string', numbers: [0], _id: null })
+  ).toThrow()
+
+  expect(() =>
+    zodCol.insertOne({ a: 'string', b: 'string', numbers: [0], _id: 'idStr' })
+  ).toThrow()
+
   expect(() => zodCol.insertMany([{ a: 0, b: 0 }])).toThrow()
   await expect(
     zodCol.insertMany([{ a: 0, b: 'string', numbers: [7] }])

--- a/test/zod-collection.test.ts
+++ b/test/zod-collection.test.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod'
 import { convertToZodCollection } from '../src'
 import { closeDb, mkTsTestCollection } from './util'
+import { ObjectId } from 'mongodb'
 
 const ZExample = z.object({
   a: z.number(),
@@ -24,6 +25,15 @@ test('Documents should be parsed correctly on insert', async () => {
   await expect(
     zodCol.insertOne({ a: 0, b: 'string', numbers: [0] })
   ).resolves.toBeTruthy()
+
+  const id = new ObjectId()
+  const { insertedId } = await zodCol.insertOne({
+    a: 0,
+    b: 'string',
+    numbers: [0],
+    _id: id,
+  })
+  expect(insertedId.equals(id)).toBeTruthy()
 
   expect(() => zodCol.insertMany([{ a: 0, b: 0 }])).toThrow()
   await expect(

--- a/test/zod-collection.test.ts
+++ b/test/zod-collection.test.ts
@@ -1,30 +1,34 @@
 import { z } from 'zod'
-import { convertToZodCollection } from '../src'
+import { convertToZodCollection, TsReadWriteCollection, WithTime } from '../src'
 import { closeDb, mkTsTestCollection } from './util'
-import { ObjectId } from 'mongodb'
+import { ObjectId, WithId } from 'mongodb'
 
 const ZExample = z.object({
   a: z.number(),
   b: z.string(),
   numbers: z.number().array(),
 })
+interface ZExample extends z.infer<typeof ZExample> {}
 
 const mkZodCollection = async () => {
-  const col = await mkTsTestCollection()
-  // use any here so we can insert wrong values without upsetting typescript
-  const zodCol = convertToZodCollection<any>(col, ZExample)
-  return zodCol
+  const col = await mkTsTestCollection<WithTime<ZExample>>()
+  return convertToZodCollection(col, ZExample)
 }
 
 test('Documents should be parsed correctly on insert', async () => {
   const zodCol = await mkZodCollection()
 
   expect(() =>
+    // @ts-expect-error
     zodCol.insertOne({ a: 'string', b: 'string', numbers: [9] })
   ).toThrow()
   await expect(
     zodCol.insertOne({ a: 0, b: 'string', numbers: [0] })
   ).resolves.toBeTruthy()
+})
+
+test('Should allow inserting documents with _id even if not in schema', async () => {
+  const zodCol = await mkZodCollection()
 
   const id = new ObjectId()
   const { insertedId } = await zodCol.insertOne({
@@ -36,17 +40,19 @@ test('Documents should be parsed correctly on insert', async () => {
   expect(insertedId.equals(id)).toBeTruthy()
 
   expect(() =>
+    // @ts-expect-error
     zodCol.insertOne({ a: 'string', b: 'string', numbers: [0], _id: null })
   ).toThrow()
 
   expect(() =>
-    zodCol.insertOne({ a: 'string', b: 'string', numbers: [0], _id: 'idStr' })
+    zodCol.insertOne({
+      a: 0,
+      b: 'string',
+      numbers: [0],
+      // @ts-expect-error
+      _id: 'idStr',
+    })
   ).toThrow()
-
-  expect(() => zodCol.insertMany([{ a: 0, b: 0 }])).toThrow()
-  await expect(
-    zodCol.insertMany([{ a: 0, b: 'string', numbers: [7] }])
-  ).resolves.toBeTruthy()
 })
 
 test('Documents should be parsed correctly on update', async () => {
@@ -57,17 +63,20 @@ test('Documents should be parsed correctly on update', async () => {
     zodCol.updateOne({}, { $set: { a: 0 as any } })
   ).resolves.toBeTruthy()
 
-  expect(() => zodCol.updateOne({}, { $pull: { a: 0 as any } })).toThrow()
+  // @ts-expect-error
+  expect(() => zodCol.updateOne({}, { $pull: { a: 0 } })).toThrow()
   await expect(
     zodCol.updateOne({}, { $pull: { numbers: 0 as any } })
   ).resolves.toBeTruthy()
 
-  expect(() => zodCol.updateOne({}, { $push: { a: 0 as any } })).toThrow()
+  // @ts-expect-error
+  expect(() => zodCol.updateOne({}, { $push: { a: 0 } })).toThrow()
   await expect(
     zodCol.updateOne({}, { $push: { numbers: 0 as any } })
   ).resolves.toBeTruthy()
 
-  expect(() => zodCol.updateOne({}, { $addToSet: { a: 0 as any } })).toThrow()
+  // @ts-expect-error
+  expect(() => zodCol.updateOne({}, { $addToSet: { a: 0 } })).toThrow()
   await expect(
     zodCol.updateOne({}, { $addToSet: { numbers: 0 as any } })
   ).resolves.toBeTruthy()

--- a/test/zod-collection.test.ts
+++ b/test/zod-collection.test.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod'
-import { convertToZodCollection, TsReadWriteCollection, WithTime } from '../src'
+import { convertToZodCollection, WithTime } from '../src'
 import { closeDb, mkTsTestCollection } from './util'
-import { ObjectId, WithId } from 'mongodb'
+import { ObjectId } from 'mongodb'
 
 const ZExample = z.object({
   a: z.number(),
@@ -24,6 +24,12 @@ test('Documents should be parsed correctly on insert', async () => {
   ).toThrow()
   await expect(
     zodCol.insertOne({ a: 0, b: 'string', numbers: [0] })
+  ).resolves.toBeTruthy()
+
+  // @ts-expect-error
+  expect(() => zodCol.insertMany([{ a: 0, b: 0 }])).toThrow()
+  await expect(
+    zodCol.insertMany([{ a: 0, b: 'string', numbers: [7] }])
   ).resolves.toBeTruthy()
 })
 
@@ -52,6 +58,18 @@ test('Should allow inserting documents with _id even if not in schema', async ()
       // @ts-expect-error
       _id: 'idStr',
     })
+  ).toThrow()
+
+  expect(() =>
+    zodCol.insertMany([
+      {
+        a: 0,
+        b: 'string',
+        numbers: [0],
+        // @ts-expect-error
+        _id: 'idStr',
+      },
+    ])
   ).toThrow()
 })
 


### PR DESCRIPTION
The type system allows passing `_id` to `insertOne` and `insertMany` even if `_id` is not in the Zod schema. However, our validation strips `_id` out of the calls, which is unexpected.

Before modifying `preInsert`:
![image](https://github.com/user-attachments/assets/6731d503-c591-47ac-9d50-2ff1e55199eb)

After: 
![image](https://github.com/user-attachments/assets/27eb6be5-3b10-461b-a336-77b42d9803f2)
